### PR TITLE
Wrap RSS descriptions in CDATA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+lxml


### PR DESCRIPTION
## Summary
- Use lxml and CDATA sections for item descriptions so RSS readers render line breaks correctly
- Add lxml dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile generate_rss.py`
- `python generate_rss.py visprsd`


------
https://chatgpt.com/codex/tasks/task_e_68a4f15bd02c832893fee0b64b29545b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - RSS descriptions now preserve original HTML via CDATA, reducing broken formatting and parsing errors.
  - Improved compatibility and rendering across feed readers.
  - More consistent XML output for feeds.

- Refactor
  - Modernized XML generation to improve reliability and maintainability.

- Chores
  - Added a new dependency required for feed generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->