### PR TITLE
Add Ruff linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --output-format=github .


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint with Ruff and output GitHub formatted results

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a8fe3182948328b3a2485e39ed3e98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated linting workflow in CI that runs on pushes and pull requests.
  * Uses Ruff to check Python code and reports results directly in GitHub with inline annotations.
  * Improves code quality, provides faster feedback on style and errors, and standardizes checks across contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->